### PR TITLE
Unit Test Updates - 3.x related

### DIFF
--- a/tests/SitemapPageTest.php
+++ b/tests/SitemapPageTest.php
@@ -7,6 +7,8 @@ class SitemapPageTest extends FunctionalTest {
 
 	public static $fixture_file = 'sitemap/tests/SitemapPageTest.yml';
 
+	protected static $use_draft_site = true;
+	
 	public function testShowAll() {
 		$sitemap = new SitemapPage();
 
@@ -83,7 +85,7 @@ class SitemapPageTest extends FunctionalTest {
  */
 class SitemapPageTest_Unviewable extends SiteTree {
 
-	public function canView() {
+	public function canView($member = null) {
 		return false;
 	}
 


### PR DESCRIPTION
Updated declaration of SitemapPageTest_Unviewable::canView() to be compatible with  SiteTree::canView(), and added static to ensure Test uses the draft site content for comparison with the the fixture data (was failing via /dev/tests)
